### PR TITLE
Update Binance message handling

### DIFF
--- a/src/exchanges/binance-futures.ws.ts
+++ b/src/exchanges/binance-futures.ws.ts
@@ -20,12 +20,17 @@ export class BinanceFuturesWebsocket extends SharedWebsocket {
   onMessage = ({ data }: MessageEvent) => {
     if (!this.isDisposed) {
       try {
-        const ts = Number(data.match(/"E":(\d+)/)?.[1]);
-        const now = Number(new Date());
-        const diff = now - ts;
-        this.setLatency(diff);
-      } catch {
-        // do nothing
+        const parsed = JSON.parse(data as string);
+        const ts = parsed.E ?? parsed?.data?.E;
+
+        if (typeof ts === 'number') {
+          const diff = Date.now() - Number(ts);
+          this.setLatency(diff);
+        } else {
+          console.warn('BinanceFuturesWebsocket: timestamp not found', parsed);
+        }
+      } catch (err) {
+        console.warn('BinanceFuturesWebsocket: failed to parse message', err);
       }
     }
   };

--- a/src/exchanges/binance-spot.ws.ts
+++ b/src/exchanges/binance-spot.ws.ts
@@ -20,12 +20,17 @@ export class BinanceSpotWebsocket extends SharedWebsocket {
   onMessage = ({ data }: MessageEvent) => {
     if (!this.isDisposed) {
       try {
-        const ts = Number(data.match(/"E":(\d+)/)?.[1]);
-        const now = Number(new Date());
-        const diff = now - ts;
-        this.setLatency(diff);
-      } catch {
-        // do nothing
+        const parsed = JSON.parse(data as string);
+        const ts = parsed.E ?? parsed?.data?.E;
+
+        if (typeof ts === 'number') {
+          const diff = Date.now() - Number(ts);
+          this.setLatency(diff);
+        } else {
+          console.warn('BinanceSpotWebsocket: timestamp not found', parsed);
+        }
+      } catch (err) {
+        console.warn('BinanceSpotWebsocket: failed to parse message', err);
       }
     }
   };


### PR DESCRIPTION
## Summary
- parse Binance Spot & Futures websocket messages as JSON
- extract event timestamps from `E` or `data.E`
- warn when timestamps are missing

## Testing
- `npm run lint` *(fails: Cannot find type definition file for 'solid-start/env')*

------
https://chatgpt.com/codex/tasks/task_b_685c3a491860832491b4627b5f30a53b