### PR TITLE
Add WebSocket error handling

### DIFF
--- a/src/components/latency-table.component.tsx
+++ b/src/components/latency-table.component.tsx
@@ -1,4 +1,4 @@
-import { For, onCleanup, onMount } from 'solid-js';
+import { For, Show, createMemo, onCleanup, onMount } from 'solid-js';
 
 import { BinanceFuturesWebsocket } from '~/exchanges/binance-futures.ws';
 import { BinanceSpotWebsocket } from '~/exchanges/binance-spot.ws';
@@ -57,6 +57,21 @@ const LatencyTable = () => {
     wooxSpot.close();
     wooxFutures.close();
   });
+
+  const showWarning = createMemo(
+    () =>
+      bybitSpot.hasError() ||
+      bybitFutures.hasError() ||
+      bybitFuturesv3.hasError() ||
+      bybitSpotv3.hasError() ||
+      bybitSpotv1.hasError() ||
+      binanceSpot.hasError() ||
+      binanceFutures.hasError() ||
+      okxSpot.hasError() ||
+      okxFutures.hasError() ||
+      wooxSpot.hasError() ||
+      wooxFutures.hasError()
+  );
 
   const exchanges = [
     {
@@ -128,7 +143,13 @@ const LatencyTable = () => {
   ];
 
   return (
-    <table class="table table-auto w-full max-w-[700px] mx-auto">
+    <>
+      <Show when={showWarning()}>
+        <div class="text-center text-orange-500 text-sm mb-2">
+          Connection issues detected. Results may be inaccurate.
+        </div>
+      </Show>
+      <table class="table table-auto w-full max-w-[700px] mx-auto">
       <thead>
         <tr>
           <th class="text-left uppercase">Exchange</th>
@@ -175,6 +196,7 @@ const LatencyTable = () => {
         </tr>
       </tbody>
     </table>
+    </>
   );
 };
 

--- a/src/exchanges/shared.ws.ts
+++ b/src/exchanges/shared.ws.ts
@@ -6,31 +6,53 @@ export class SharedWebsocket {
   endpoint: string;
   isDisposed = false;
 
+  errorCount = 0;
+  hasError: Accessor<boolean>;
+  setHasError: Setter<boolean>;
+
   latency: Accessor<number>;
   setLatency: Setter<number>;
-
+  
   constructor(endpoint: string) {
     this.endpoint = endpoint;
 
     const [latency, setLatency] = createSignal(0);
     this.latency = latency;
     this.setLatency = setLatency;
+
+    const [hasError, setHasError] = createSignal(false);
+    this.hasError = hasError;
+    this.setHasError = setHasError;
   }
+
 
   connect = () => {
     this.ws = new WebSocket(this.endpoint);
     this.ws.addEventListener('open', this.onOpen);
     this.ws.addEventListener('message', this.onMessage);
     this.ws.addEventListener('close', this.onClose);
+    this.ws.addEventListener('error', this.onError);
   };
 
-  onOpen = () => {};
+  onOpen = () => {
+    this.errorCount = 0;
+    this.setHasError(false);
+  };
   onMessage = (_event: MessageEvent) => {};
+
+  onError = (event: Event) => {
+    console.error(`[WebSocket error] ${this.endpoint}`, event);
+    this.errorCount += 1;
+    if (this.errorCount >= 3) {
+      this.setHasError(true);
+    }
+  };
 
   onClose = () => {
     this?.ws?.removeEventListener?.('open', this.onOpen);
     this?.ws?.removeEventListener?.('message', this.onMessage);
     this?.ws?.removeEventListener?.('close', this.onClose);
+    this?.ws?.removeEventListener?.('error', this.onError);
     this.ws = undefined;
 
     if (!this.isDisposed) {


### PR DESCRIPTION
## Summary
- add tracking for socket errors in `SharedWebsocket`
- display a warning if repeated errors occur

## Testing
- `npm run lint` *(fails: Cannot find type definition file for 'solid-start/env')*

------
https://chatgpt.com/codex/tasks/task_b_685c3a47ae0c83249246f7522caa255b