### PR TITLE
Fix Binance Spot websocket endpoint

### DIFF
--- a/src/exchanges/binance-spot.ws.ts
+++ b/src/exchanges/binance-spot.ws.ts
@@ -2,7 +2,9 @@ import { SharedWebsocket } from './shared.ws';
 
 export class BinanceSpotWebsocket extends SharedWebsocket {
   constructor() {
-    super('wss://stream.binance.com/ws');
+    // use the official Binance secure websocket endpoint
+    // explicitly specify port 9443 to avoid connection errors
+    super('wss://stream.binance.com:9443/ws');
   }
 
   onOpen = () => {


### PR DESCRIPTION
## Summary
- point Binance Spot websocket connection to the official secure endpoint

## Testing
- `npm run lint` *(fails: Cannot find type definition file for 'solid-start/env')*

------
https://chatgpt.com/codex/tasks/task_b_685c3e193a148324bbd227eecbac65ee